### PR TITLE
Changes

### DIFF
--- a/loaders/player_kills.py
+++ b/loaders/player_kills.py
@@ -39,7 +39,6 @@ def get_player_kill_counts(parser: DemoParser) -> pd.DataFrame:
     # rename columns to match that of read_demo.py
     player_kills_df = player_kills_df.rename(
         columns={
-            "total_rounds_played": "round_id",
             "attacker_name": "player_name",
             "kills": "player_kills",
         }


### PR DESCRIPTION
- Updated to accomodate for exit frags

More technical description of change:
- The total_rounds_played field increments automatically when the round is won.
- Because of this, exit frags or frags after the win condition has been meet are instead credited for the next term.
- This is rectified by instead binning them by their round start times.